### PR TITLE
Fix help command.

### DIFF
--- a/src/main/java/tech/ypsilon/bbbot/discord/command/HelpCommand.java
+++ b/src/main/java/tech/ypsilon/bbbot/discord/command/HelpCommand.java
@@ -22,7 +22,7 @@ public class HelpCommand extends Command {
                 builder.append(command.getAlias()[i]);
                 if (i != command.getAlias().length-1) builder.append(" | ");
             }
-            b.addField(builder.toString(), command.getDescription(), false);
+            b.addField(builder.toString(), (command.getDescription() == null ? "" : command.getDescription()), false);
         }
         e.getChannel().sendMessage(b.build()).queue();
     }


### PR DESCRIPTION
Crash when description from command is null