### PR TITLE
Fix Umlaute and add tip for upper and lower case

### DIFF
--- a/src/main/java/tech/ypsilon/bbbot/discord/command/DudenCommand.java
+++ b/src/main/java/tech/ypsilon/bbbot/discord/command/DudenCommand.java
@@ -39,6 +39,9 @@ public class DudenCommand extends LegacyCommand {
             input.append(s).append(" ");
         }
         input = new StringBuilder(input.toString().trim());
+        input = new StringBuilder(input.toString().replaceAll("Ä", "Ae").replaceAll("Ö", "Oe")
+                .replaceAll("Ü", "Ue").replaceAll("ä", "ae").replaceAll("ö", "oe")
+                .replaceAll("ü", "üe").replaceAll("ß", "sz"));
 
         if(!input.toString().matches("^[A-Za-z -]+$")){
             e.getChannel().sendMessage(EmbedUtil.createErrorEmbed()
@@ -72,7 +75,8 @@ public class DudenCommand extends LegacyCommand {
         }catch(HttpStatusException ex){
             if(ex.getStatusCode() == 404){
                 e.getChannel().sendMessage(EmbedUtil.createErrorEmbed()
-                        .addField("Wort nicht gefunden", "Das eingegebene Wort wurde nicht gefunden", false)
+                        .addField("Wort nicht gefunden", "Das eingegebene Wort wurde nicht gefunden " +
+                                "(Tipp: Achte auf Groß- und Kleinschreibung)", false)
                         .build()).queue();
             }else{
                 ButterBrot.LOGGER.error("Error while lookup up a word on duden.de", ex);


### PR DESCRIPTION
Duden.de does not handle Umlaute. This characters have to be converted. For example: Ü -> Ue or ß -> sz

Because mutiple users got a error message when searching for words in lower case, that there upper case, I added this message at the end of the error message: "Tipp: Achte auf Groß- und Kleinschreibung"